### PR TITLE
fix(decimals): prevent decimals in AddMoney to bank accounts

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -244,7 +244,7 @@ end)
 
 QBCore.Functions.CreateCallback('qb-crypto:server:BuyCrypto', function(source, cb, data)
     local Player = QBCore.Functions.GetPlayer(source)
-    local total_price = tonumber(tonumber(data.Coins) * tonumber(Crypto.Worth["qbit"]))
+    local total_price = math.floor(tonumber(data.Coins) * tonumber(Crypto.Worth["qbit"]))
     if Player.PlayerData.money.bank >= total_price then
         local CryptoData = {
             History = Crypto.History["qbit"],
@@ -272,7 +272,7 @@ QBCore.Functions.CreateCallback('qb-crypto:server:SellCrypto', function(source, 
             WalletId = Player.PlayerData.metadata["walletid"],
         }
         Player.Functions.RemoveMoney('crypto', tonumber(data.Coins))
-        local amount = tonumber(tonumber(data.Coins) * tonumber(Crypto.Worth["qbit"]))
+        local amount = math.floor(tonumber(data.Coins) * tonumber(Crypto.Worth["qbit"]))
         TriggerClientEvent('qb-phone:client:AddTransaction', source, Player, data, "You have "..tonumber(data.Coins).." Qbit('s) sold!", "Depreciation")
         Player.Functions.AddMoney('bank', amount)
         cb(CryptoData)

--- a/server/main.lua
+++ b/server/main.lua
@@ -244,7 +244,7 @@ end)
 
 QBCore.Functions.CreateCallback('qb-crypto:server:BuyCrypto', function(source, cb, data)
     local Player = QBCore.Functions.GetPlayer(source)
-    local total_price = tonumber(data.Coins) * tonumber(Crypto.Worth["qbit"])
+    local total_price = tonumber(tonumber(data.Coins) * tonumber(Crypto.Worth["qbit"]))
     if Player.PlayerData.money.bank >= total_price then
         local CryptoData = {
             History = Crypto.History["qbit"],
@@ -272,8 +272,9 @@ QBCore.Functions.CreateCallback('qb-crypto:server:SellCrypto', function(source, 
             WalletId = Player.PlayerData.metadata["walletid"],
         }
         Player.Functions.RemoveMoney('crypto', tonumber(data.Coins))
+        local amount = tonumber(tonumber(data.Coins) * tonumber(Crypto.Worth["qbit"]))
         TriggerClientEvent('qb-phone:client:AddTransaction', source, Player, data, "You have "..tonumber(data.Coins).." Qbit('s) sold!", "Depreciation")
-        Player.Functions.AddMoney('bank', tonumber(data.Coins) * tonumber(Crypto.Worth["qbit"]))
+        Player.Functions.AddMoney('bank', amount)
         cb(CryptoData)
     else
         cb(false)


### PR DESCRIPTION
**Describe Pull request**
Convert all calculations to integers by stripping the decimal with `tonumber`.

If your PR is to fix an issue mention that issue here
#47 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes (Be honest)
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes