### PR TITLE
Fix locales

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -9,20 +9,20 @@ local Translations = {
         you_have_exchanged_your_cryptostick_for = 'You have exchanged your Cryptostick for: %{amount} QBit(s)'
     },
     credit = {
-        there_are_amount_credited = 'There are %{amount} Qbit(s) credited!',
-        you_have_qbit_purchased = 'You have %{dataCoins} Qbit(s) purchased!'
+        there_are_amount_credited = 'Yuo have been credited %{amount} Qbit(s)!',
+        you_have_qbit_purchased = 'You have purchased %{dataCoins} Qbit(s)!'
     },
     depreciation = {
-        you_have_sold = 'You have %{dataCoins} Qbit(s) sold!'
+        you_have_sold = 'You have sold %{dataCoins} Qbit(s)!'
     },
     text = {
         enter_usb = '[E] - Enter USB',
         system_is_rebooting = 'System is rebooting - %{rebootInfoPercentage} %',
-        you_have_not_given_a_new_value = 'You have not given a new value .. Current values: %{crypto}',
-        this_crypto_does_not_exist = 'This Crypto does not exist :(, available: Qbit',
+        you_have_not_given_a_new_value = 'You have not given a new value ... Current values: %{crypto}',
+        this_crypto_does_not_exist = 'This crypto does not exist, available crypto(s): Qbit',
         you_have_not_provided_crypto_available_qbit = 'You have not provided Crypto, available: Qbit',
-        the_qbit_has_a_value_of = 'The Qbit has a value of: %{crypto}',
-        you_have_with_a_value_of = 'You have: %{playerPlayerDataMoneyCrypto} QBit, with a value of: %{mypocket},-'
+        the_qbit_has_a_value_of = 'Qbit has a value of: %{crypto}',
+        you_have_with_a_value_of = 'You have %{playerPlayerDataMoneyCrypto} QBit(s) with a value of: %{mypocket},-'
     }
 }
 

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -1,8 +1,6 @@
 local Translations = {
     error = {
         you_dont_have_a_cryptostick = 'You don\'t have a cryptostick',
-        one_bus_active = 'You can only have one active bus at a time',
-        drop_off_passengers = 'Drop off the passengers before you stop working',
         cryptostick_malfunctioned = 'Cryptostick malfunctioned'
     },
     success = {


### PR DESCRIPTION
**Describe Pull request**
This PR fixes the grammar of the messages used in locales/en.lua  (English)

This also removes two unused strings from all locales 
`one_bus_active` and `drop_off_passengers` which appear to have be erroneously leftover from bus job?  #61 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all its functionality? yes. tested on the latest qb-core installation
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
