### PR TITLE
Bug/fix locales

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -1,28 +1,26 @@
 local Translations = {
     error = {
         you_dont_have_a_cryptostick = 'You don\'t have a cryptostick',
-        one_bus_active = 'You can only have one active bus at a time',
-        drop_off_passengers = 'Drop off the passengers before you stop working',
         cryptostick_malfunctioned = 'Cryptostick malfunctioned'
     },
     success = {
         you_have_exchanged_your_cryptostick_for = 'You have exchanged your Cryptostick for: %{amount} QBit(s)'
     },
     credit = {
-        there_are_amount_credited = 'There are %{amount} Qbit(s) credited!',
-        you_have_qbit_purchased = 'You have %{dataCoins} Qbit(s) purchased!'
+        there_are_amount_credited = 'You have been credited %{amount} Qbit(s)!',
+        you_have_qbit_purchased = 'You have purchased %{dataCoins} Qbit(s)!'
     },
-    depreciation = {
-        you_have_sold = 'You have %{dataCoins} Qbit(s) sold!'
+    debit = {
+        you_have_sold = 'You have sold %{dataCoins} Qbit(s)!'
     },
     text = {
         enter_usb = '[E] - Enter USB',
         system_is_rebooting = 'System is rebooting - %{rebootInfoPercentage} %',
-        you_have_not_given_a_new_value = 'You have not given a new value .. Current values: %{crypto}',
-        this_crypto_does_not_exist = 'This Crypto does not exist :(, available: Qbit',
+        you_have_not_given_a_new_value = 'You have not given a new value ... Current value: %{crypto}',
+        this_crypto_does_not_exist = 'This crypto does not exist, available crypto(s): Qbit',
         you_have_not_provided_crypto_available_qbit = 'You have not provided Crypto, available: Qbit',
-        the_qbit_has_a_value_of = 'The Qbit has a value of: %{crypto}',
-        you_have_with_a_value_of = 'You have: %{playerPlayerDataMoneyCrypto} QBit, with a value of: %{mypocket},-'
+        the_qbit_has_a_value_of = 'Qbit has a value of: %{crypto}',
+        you_have_with_a_value_of = 'You have %{playerPlayerDataMoneyCrypto} QBit(s) with a value of: %{mypocket},-'
     }
 }
 

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -1,8 +1,6 @@
 local Translations = {
     error = {
         you_dont_have_a_cryptostick = 'No tienes un cryptostick',
-        one_bus_active = 'Sólo puedes tener un autobús activo a la vez',
-        drop_off_passengers = 'Deja a los pasajeros antes de dejar de trabajar',
         cryptostick_malfunctioned = 'El criptostick ha funcionado mal'
     },
     success = {
@@ -12,7 +10,7 @@ local Translations = {
         there_are_amount_credited = '¡Hay %{amount} Qbit(s) acreditados!',
         you_have_qbit_purchased = 'Has comprado %{dataCoins} Qbit(s)!'
     },
-    depreciation = {
+    debit = {
         you_have_sold = 'Has vendido %{dataCoins} Qbit(s)!'
     },
     text = {

--- a/locales/pt.lua
+++ b/locales/pt.lua
@@ -1,8 +1,6 @@
 local Translations = {
     error = {
         you_dont_have_a_cryptostick = 'Não possui um Cryptostick',
-        one_bus_active = 'Só pode ter um autocarro activo.',
-        drop_off_passengers = 'Deixe os passageiros antes de parar de trabalhar',
         cryptostick_malfunctioned = 'Cryptostick com defeito'
     },
     success = {
@@ -12,7 +10,7 @@ local Translations = {
         there_are_amount_credited = 'Foram creditados %{amount} Qbit(s)!',
         you_have_qbit_purchased = 'Comprou %{dataCoins} Qbit(s)!'
     },
-    depreciation = {
+    debit = {
         you_have_sold = 'Vendeu %{dataCoins} Qbit(s)!'
     },
     text = {

--- a/server/main.lua
+++ b/server/main.lua
@@ -290,7 +290,7 @@ QBCore.Functions.CreateCallback('qb-crypto:server:SellCrypto', function(source, 
         }
         Player.Functions.RemoveMoney('crypto', tonumber(data.Coins))
         local amount = math.floor(tonumber(data.Coins) * tonumber(Crypto.Worth["qbit"]))
-        TriggerClientEvent('qb-phone:client:AddTransaction', source, Player, data, Lang:t('depreciation.you_have_sold',{dataCoins = tonumber(data.Coins)}), "Depreciation")
+        TriggerClientEvent('qb-phone:client:AddTransaction', source, Player, data, Lang:t('debit.you_have_sold',{dataCoins = tonumber(data.Coins)}), "Debit")
         Player.Functions.AddMoney('bank', amount)
         cb(CryptoData)
     else
@@ -319,7 +319,7 @@ QBCore.Functions.CreateCallback('qb-crypto:server:TransferCrypto', function(sour
                 WalletId = Player.PlayerData.metadata["walletid"],
             }
             Player.Functions.RemoveMoney('crypto', tonumber(data.Coins))
-            TriggerClientEvent('qb-phone:client:AddTransaction', source, Player, data, "You have "..tonumber(data.Coins).." Qbit('s) transferred!", "Depreciation")
+            TriggerClientEvent('qb-phone:client:AddTransaction', source, Player, data, "You have "..tonumber(data.Coins).." Qbit('s) transferred!", "Debit")
             local Target = QBCore.Functions.GetPlayerByCitizenId(result[1].citizenid)
 
             if Target ~= nil then


### PR DESCRIPTION
**Describe Pull request**
This PR does the following: 

- fixes the grammar of the messages used in `locales/en.lua` (English)
- removes two unused strings from all locales `one_bus_active` and `drop_off_passengers` which appear to have be erroneously leftover from bus job? https://github.com/qbcore-framework/qb-crypto/issues/61
- changes 'depreciation' to 'debit' in the locale and appropriate functions to be consistent


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes. tested on the latest qb-core installation
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes

